### PR TITLE
Fixed Image Rendering Bugs

### DIFF
--- a/client/src/assets/overview.sass
+++ b/client/src/assets/overview.sass
@@ -90,6 +90,7 @@
       justify-content: flex-start
       width: 328px
       .style-thumbnail
+        background-image: url(https://upload.wikimedia.org/wikipedia/commons/1/14/No_Image_Available.jpg)
         cursor: pointer
         margin: 5px
         border: 1px solid grey

--- a/client/src/components/overview/ImageGallery.jsx
+++ b/client/src/components/overview/ImageGallery.jsx
@@ -38,6 +38,13 @@ const ImageGallery = ({ product, style, activeImageIndex, setActiveImageIndex, e
 
   }, [style, product, activeImageIndex]);
 
+  useEffect(() => {
+    if (currentPhotoURL === 'https://upload.wikimedia.org/wikipedia/commons/1/14/No_Image_Available.jpg') {
+      setExpandedView(false);
+      setZoomedMode(false);
+    }
+  }, [currentPhotoURL]);
+
   const scrollThumbnails = (incrementValue) => {
     var newRange = [thumbnailRange[0] + incrementValue, thumbnailRange[1] + incrementValue];
     setThumbnailRange(newRange);
@@ -61,7 +68,11 @@ const ImageGallery = ({ product, style, activeImageIndex, setActiveImageIndex, e
   };
 
   const toggleExpandedView = (e) => {
-    setExpandedView(!expandedView);
+    if (currentPhotoURL === 'https://upload.wikimedia.org/wikipedia/commons/1/14/No_Image_Available.jpg') {
+      setExpandedView(false);
+    } else {
+      setExpandedView(!expandedView);
+    }
   };
 
   const toggleZoomedView = () => {
@@ -76,7 +87,7 @@ const ImageGallery = ({ product, style, activeImageIndex, setActiveImageIndex, e
   if (Array.isArray(photos) && photos.length) {
     if (expandedView === false) {
       return (
-        <section className="image-gallery" id="image-gallery-default" style={{backgroundImage: `url(${currentPhotoURL})`}} onClick={(e) => toggleExpandedView(e)}>
+        <section className="image-gallery" id="image-gallery-default" style={currentPhotoURL === 'https://upload.wikimedia.org/wikipedia/commons/1/14/No_Image_Available.jpg' ? {backgroundImage: `url(${currentPhotoURL})`, cursor: 'default'} : {backgroundImage: `url(${currentPhotoURL})`}} onClick={(e) => toggleExpandedView(e)}>
           <div id="thumbnail-container">
             <div className="thumbnail-chevron-container">
               { thumbnailRange[0] > 0 ? (

--- a/client/src/components/overview/ImageGallery.jsx
+++ b/client/src/components/overview/ImageGallery.jsx
@@ -12,8 +12,6 @@ const ImageGallery = ({ product, style, activeImageIndex, setActiveImageIndex, e
   const [bounds, setBounds] = useState({});
 
   useEffect(() => {
-    setCurrentPhotoURL('https://upload.wikimedia.org/wikipedia/commons/1/14/No_Image_Available.jpg');
-
     if (!!style.photos) {
       setPhotos(style.photos);
     }
@@ -22,12 +20,22 @@ const ImageGallery = ({ product, style, activeImageIndex, setActiveImageIndex, e
   useEffect(() => {
     setZoomedMode(false);
     setExpandedView(false);
+    setThumbnailRange([0, 7]);
   }, [product]);
 
   useEffect(() => {
-    if (!!style.photos && style.photos[activeImageIndex].url !== undefined) {
-      setCurrentPhotoURL(style.photos[activeImageIndex].url);
+
+
+    if (!!style.photos) {
+      if (!!style.photos[activeImageIndex] && style.photos[activeImageIndex].url !== null) {
+        setCurrentPhotoURL(style.photos[activeImageIndex].url);
+      } else {
+        setCurrentPhotoURL('https://upload.wikimedia.org/wikipedia/commons/1/14/No_Image_Available.jpg');
+      }
+    } else {
+      setCurrentPhotoURL('https://upload.wikimedia.org/wikipedia/commons/1/14/No_Image_Available.jpg');
     }
+
   }, [style, product, activeImageIndex]);
 
   const scrollThumbnails = (incrementValue) => {

--- a/client/src/components/overview/Overview.jsx
+++ b/client/src/components/overview/Overview.jsx
@@ -43,7 +43,20 @@ const Overview = ({ productId }) => {
         setReviewsData(ratings);
       });
 
+    setActiveImageIndex(0);
+
   }, [productId]);
+
+  useEffect(() => {
+
+    if (activeImageIndex !== 0) {
+      if (style.photos.length >= activeImageIndex) {
+        setActiveImageIndex(0);
+      }
+
+    }
+
+  }, [style]);
 
   return (
     <section id="overview">

--- a/client/src/components/overview/StyleSelector.jsx
+++ b/client/src/components/overview/StyleSelector.jsx
@@ -29,18 +29,35 @@ const StyleSelector = ({ productStyles, style, setStyle }) => {
               <div key={i} className="styles-row">
                 { array.map((productStyle, k) => {
                   if (style.style_id === productStyle.style_id) {
-                    return (
-                      <div key={k} style={{backgroundImage: `url(${productStyle.photos[0].thumbnail_url})`}}className="style-thumbnail">
-                        <span className="fa-layers fa-fw">
-                          <FontAwesomeIcon icon={faCircle} fixedWidth color="LightGray" />
-                          <FontAwesomeIcon icon={faCheck} fixedWidth color="#2b2d42" size="2xs" />
-                        </span>
-                      </div>
-                    );
+                    if (!!productStyle.photos[0].thumbnail_url) {
+                      return (
+                        <div key={k} style={{backgroundImage: `url(${productStyle.photos[0].thumbnail_url})`}} className="style-thumbnail">
+                          <span className="fa-layers fa-fw">
+                            <FontAwesomeIcon icon={faCircle} fixedWidth color="LightGray" />
+                            <FontAwesomeIcon icon={faCheck} fixedWidth color="#2b2d42" size="2xs" />
+                          </span>
+                        </div>
+                      );
+                    } else {
+                      return (
+                        <div key={k} className="style-thumbnail">
+                          <span className="fa-layers fa-fw">
+                            <FontAwesomeIcon icon={faCircle} fixedWidth color="LightGray" />
+                            <FontAwesomeIcon icon={faCheck} fixedWidth color="#2b2d42" size="2xs" />
+                          </span>
+                        </div>
+                      );
+                    }
                   } else {
-                    return (
-                      <div key={k} style={{backgroundImage: `url(${productStyle.photos[0].thumbnail_url})`}}className="style-thumbnail" onClick={() => handleClick(productStyle)}/>
-                    );
+                    if (!!productStyle.photos[0].thumbnail_url) {
+                      return (
+                        <div key={k} style={{backgroundImage: `url(${productStyle.photos[0].thumbnail_url})`}} className="style-thumbnail" onClick={() => handleClick(productStyle)}/>
+                      );
+                    } else {
+                      return (
+                        <div key={k} className="style-thumbnail" onClick={() => handleClick(productStyle)}/>
+                      );
+                    }
                   }
                 })}
               </div>


### PR DESCRIPTION
- App should not crash when switching to a product w/o images
- App should not crash when switching to a style w/ fewer images than current style
- Thumbnails in image gallery should render correctly when switching to a product/style with fewer images than previously selected product/style
- App should show placeholder images when style/product has no images
- App should disable expanded view if style/product has no images